### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-pip install transformers==4.42.0
-pip install accelerate==0.27.2
-pip install tiktoken==0.7.0
-pip install einops==0.7.0
-pip install transformers_stream_generator==0.0.4
-pip install peft==0.11.1
-pip install deepspeed==0.10.0
-pip install pandas==2.0.1
-pip install Jinja2==3.1.4
-pip install trl==0.9.6
+transformers==4.42.0
+accelerate==0.27.2
+tiktoken==0.7.0
+einops==0.7.0
+transformers_stream_generator==0.0.4
+peft==0.11.1
+deepspeed==0.10.0
+pandas==2.0.1
+Jinja2==3.1.4
+trl==0.9.6


### PR DESCRIPTION
Fix the error that occurs when running `pip install -r requirements.txt`. 

ERROR: Invalid requirement: 'pip install transformers==4.42.0': Expected end or semicolon (after name and no valid version specifier)
    pip install transformers==4.42.0
        ^ (from line 1 of requirements.txt)